### PR TITLE
TET-76 Remove menu titles on model page

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,11 +1,13 @@
 import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 
 import { LanguageSelector } from './LanguageSelector'
 import Logo from './ui/Logo'
 
 const Navbar = () => {
   const { t } = useTranslation()
+  const location = useLocation()
+  const displayMenuTitles = location.pathname !== '/model'
 
   const menuTitles = [
     t('navbar.menuTitles.home'),
@@ -21,13 +23,14 @@ const Navbar = () => {
       {item}
     </Link>
   ))
+
   return (
     <div className="mx-auto hidden w-full max-w-7xl flex-shrink-0 items-center justify-between pt-8 font-geologica md:flex">
       <Link to={'/'} className="flex cursor-pointer flex-col items-center justify-center pl-3 text-app-blue">
         <Logo />
         <p className="uppercase">tetrahedron</p>
       </Link>
-      <div className="flex items-center justify-center gap-7">{menuItems}</div>
+      <div className="flex items-center justify-center gap-7">{displayMenuTitles ? menuItems : null}</div>
       <LanguageSelector />
     </div>
   )

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -30,7 +30,7 @@ const Navbar = () => {
         <Logo />
         <p className="uppercase">tetrahedron</p>
       </Link>
-      <div className="flex items-center justify-center gap-7">{displayMenuTitles ? menuItems : null}</div>
+      {displayMenuTitles && <div className="flex items-center justify-center gap-7">{menuItems}</div>}
       <LanguageSelector />
     </div>
   )


### PR DESCRIPTION
Removed menu items in `Navbar` on the `/model` page:

![image](https://github.com/user-attachments/assets/d4b0bae4-cd36-47d6-a82a-e0347d489a83)

Other pages have this still:

![image](https://github.com/user-attachments/assets/31b4479a-4fae-4bba-8835-6e6cdd95e7f5)
