### PR TITLE
TET-78 Fix vscode relative path imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "typescript.preferences.importModuleSpecifier": "non-relative",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {


### PR DESCRIPTION
Added `importModuleSpecifier` as `non-relative` to `.vscode/settings.json` to prevent relative imports by default